### PR TITLE
Add PLATFORM_SCHEMA_BASE to platform

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,7 +12,8 @@ from homeassistant.const import (
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import ToggleEntity
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.config_validation import PLATFORM_SCHEMA  # noqa
+from homeassistant.helpers.config_validation import (  # noqa
+    PLATFORM_SCHEMA, PLATFORM_SCHEMA_BASE)
 from homeassistant.loader import bind_hass
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
As of [Home Assistant 0.88](https://www.home-assistant.io/blog/2019/02/20/release-88/), a deprecation warning is thrown regarding unsupported extra configuration keys `name`, `host`, and `password` for this display platform.

Importing `PLATFORM_SCHEMA_BASE` fixes this issue, as [has been done with some core items](https://github.com/home-assistant/home-assistant/pull/20578).

Fixes #7.