### PR TITLE
Re-add sound_start and sound_stop for playSound and stopSound support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This component currently supports the following features of Fully Kiosk Browser:
    * loading a provided URL,
    * adjusting the tablet screen brightness,
    * turning the tablet screensaver on, off and adjusting the screensaver brightness.
+   * playing a mp3 file located on the tablet or on a http url
 
 ## Installation
 
@@ -67,3 +68,5 @@ The fully_kiosk platform provides the following services:
    * fully_kiosk.screensaver_start
    * fully_kiosk.screensaver_stop
    * fully_kiosk.set_screensaver_brightness
+   * fully_kiosk.sound_play
+   * fully_kiosk.sound_stop

--- a/fully_kiosk/services.yaml
+++ b/fully_kiosk/services.yaml
@@ -41,3 +41,20 @@ set_screensaver_brightness:
     brightness:
       description: 'Brightness level to set'
       example: '0-255'
+
+sound_play:
+  description: 'Local path on tablet or URL with mp3 file to play using Fully Kiosk Browser '
+  fields:
+    entity_id:
+      description: 'Name of the Fully Kiosk Browser device'
+      example: 'display.kitchen_wall_pad'
+    url:
+      description: 'The local file or URL to play'
+      example: 'file:///storage/emulated/0/Download/sound.mp3 or http://www.example.com/sound.mp3'
+
+sound_stop:
+  description: 'Stop play a previously started mp3 file playback'
+  fields:
+    entity_id:
+      description: 'Name of the Fully Kiosk Browser device'
+      example: 'display.kitchen_wall_pad'


### PR DESCRIPTION
I don't know what happened with https://github.com/daemondazz/homeassistant-displays/pull/11 but it seems to be missing from master again, although it got merged on 18 june ? 