### PR TITLE
Rename changed elements of deviceInfo data

### DIFF
--- a/fully_kiosk/display.py
+++ b/fully_kiosk/display.py
@@ -190,7 +190,7 @@ class FullyKioskDevice(DisplayDevice):
             _LOGGER.error(data['statustext'])
             return False
 
-        self._state = (STATE_OFF, STATE_ON)[data['isScreenOn']]
+        self._state = (STATE_OFF, STATE_ON)[data['screenOn']]
         self._attributes = {
             'manufacturer': data['deviceManufacturer'],
             'model': data['deviceModel'],

--- a/fully_kiosk/display.py
+++ b/fully_kiosk/display.py
@@ -195,7 +195,7 @@ class FullyKioskDevice(DisplayDevice):
             'manufacturer': data['deviceManufacturer'],
             'model': data['deviceModel'],
             'device_id': data['deviceID'],
-            'mac_address': data['mac'],
+            'mac_address': data['Mac'],
             'version': data['appVersionName'],
             'page': data['currentPage'],
             'battery_charging': data['plugged'],

--- a/fully_kiosk/display.py
+++ b/fully_kiosk/display.py
@@ -204,7 +204,7 @@ class FullyKioskDevice(DisplayDevice):
             'brightness': data['screenBrightness'],
             'kiosk_mode': data['kioskMode'],
             'maintenance_mode': data['maintenanceMode'],
-            'screensaver_on': (data['currentFragment'] == 'screensaver'),
+            'screensaver_on': data['isInScreensaver'],
         }
         return True
 


### PR DESCRIPTION
It seems that in Fully 1.40.x the `isScreenOn` element is no longer in the output of `deviceInfo`. 
I have replaced it with `screenOn` which provides a boolean whether the screen is on or not.

Also, the `mac` field seems to have been changed to `Mac`.